### PR TITLE
1 small bugfix, few compatibility with earlier compiler tweaks

### DIFF
--- a/drivers/regulator/cpr3-regulator.c
+++ b/drivers/regulator/cpr3-regulator.c
@@ -6086,7 +6086,7 @@ free_regulators:
  */
 int cpr3_regulator_unregister(struct cpr3_controller *ctrl)
 {
-	int i, j, rc = 0;
+	int i, j;
 
 	mutex_lock(&cpr3_controller_list_mutex);
 	list_del(&ctrl->list);
@@ -6097,7 +6097,7 @@ int cpr3_regulator_unregister(struct cpr3_controller *ctrl)
 		unregister_hotcpu_notifier(&ctrl->cpu_hotplug_notifier);
 
 	if (ctrl->ctrl_type == CPR_CTRL_TYPE_CPR4) {
-		rc = cpr3_ctrl_clear_cpr4_config(ctrl);
+		int rc = cpr3_ctrl_clear_cpr4_config(ctrl);
 		if (rc)
 			cpr3_err(ctrl, "failed to clear CPR4 configuration,rc=%d\n",
 				rc);

--- a/drivers/usb/gadget/function/f_gsi.c
+++ b/drivers/usb/gadget/function/f_gsi.c
@@ -19,7 +19,7 @@
 #include <linux/timer.h>
 #include "f_gsi.h"
 #include "rndis.h"
-#include "debug.h"
+#include "../debug.h"
 
 static unsigned int gsi_in_aggr_size;
 module_param(gsi_in_aggr_size, uint, S_IRUGO | S_IWUSR);

--- a/drivers/usb/gadget/function/f_midi.c
+++ b/drivers/usb/gadget/function/f_midi.c
@@ -32,7 +32,7 @@
 #include <linux/usb/audio.h>
 #include <linux/usb/midi.h>
 
-#include "u_f.h"
+#include "../u_f.h"
 
 MODULE_AUTHOR("Ben Williamson");
 MODULE_LICENSE("GPL v2");

--- a/drivers/usb/gadget/function/f_mtp.c
+++ b/drivers/usb/gadget/function/f_mtp.c
@@ -40,7 +40,7 @@
 #include <linux/configfs.h>
 #include <linux/usb/composite.h>
 
-#include "configfs.h"
+#include "../configfs.h"
 
 #define MTP_RX_BUFFER_INIT_SIZE    1048576
 #define MTP_BULK_BUFFER_SIZE       16384

--- a/drivers/usb/gadget/function/f_rndis.c
+++ b/drivers/usb/gadget/function/f_rndis.c
@@ -27,7 +27,7 @@
 #include "u_ether_configfs.h"
 #include "u_rndis.h"
 #include "rndis.h"
-#include "configfs.h"
+#include "../configfs.h"
 
 /*
  * This function is an RNDIS Ethernet port -- a Microsoft protocol that's

--- a/fs/ecryptfs/mmap.c
+++ b/fs/ecryptfs/mmap.c
@@ -512,11 +512,12 @@ static int ecryptfs_write_inode_size_to_xattr(struct inode *ecryptfs_inode)
 	rc = lower_inode->i_op->setxattr(lower_dentry, ECRYPTFS_XATTR_NAME,
 					 xattr_virt, size, 0);
 	mutex_unlock(&lower_inode->i_mutex);
-	if (rc)
+	if (rc) {
 		printk(KERN_ERR "Error whilst attempting to write inode size "
 		       "to lower file xattr; rc = [%d]\n", rc);
 		printk(KERN_ERR " [CCAudit] Error whilst attempting to write inode size "
 		       "to lower file xattr; rc = [%d]\n", rc);
+	}
 	kmem_cache_free(ecryptfs_xattr_cache, xattr_virt);
 out:
 	return rc;

--- a/sound/soc/msm/apq8096-auto.c
+++ b/sound/soc/msm/apq8096-auto.c
@@ -32,7 +32,7 @@
 #include <sound/q6core.h>
 #include <sound/pcm_params.h>
 #include <sound/info.h>
-#include <device_event.h>
+#include "device_event.h"
 #include "qdsp6v2/msm-pcm-routing-v2.h"
 
 #define DRV_NAME "apq8096-auto-asoc-snd"

--- a/sound/soc/msm/apq8096-i2c.c
+++ b/sound/soc/msm/apq8096-i2c.c
@@ -31,7 +31,7 @@
 #include <sound/q6core.h>
 #include <sound/pcm_params.h>
 #include <sound/info.h>
-#include <device_event.h>
+#include "device_event.h"
 #include "qdsp6v2/msm-pcm-routing-v2.h"
 #include "../codecs/wcd9xxx-common.h"
 #include "../codecs/wcd9330.h"

--- a/sound/soc/msm/msm8996.c
+++ b/sound/soc/msm/msm8996.c
@@ -31,7 +31,7 @@
 #include <sound/q6core.h>
 #include <sound/pcm_params.h>
 #include <sound/info.h>
-#include <device_event.h>
+#include "device_event.h"
 #include "qdsp6v2/msm-pcm-routing-v2.h"
 #include "../codecs/wcd9xxx-common.h"
 #include "../codecs/wcd9330.h"


### PR DESCRIPTION
This includes a small bugfix in fs/ecryptfs/mmap.c.  Pretty minor though someone may have wondered how the message was happening on their device.

Seems recent versions of GCC are expanding how far they search for includes.  This includes adjustments which allow these to compile with earlier versions.